### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX := /usr/local
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
 
@@ -10,9 +12,21 @@ all: $(BINNAME)
 
 $(BINNAME): $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS) -lconfig
+	rm $(OBJS)
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
 
-clean: $(OBJS) $(BINNAME)
-	rm $(OBJS) $(BINNAME)
+install: $(BINNAME)
+	mkdir -p $(PREFIX) $(PREFIX)/bin $(PREFIX)/share/applications
+	install -Dvm755 ./$(BINNAME) $(PREFIX)/bin/$(BINNAME)
+	install -Dvm755 ./$(BINNAME).desktop $(PREFIX)/share/applications/$(BINNAME).desktop
+
+$(PREFIX)/bin/$(BINNAME): install
+
+uninstall: $(PREFIX)/bin/$(BINNAME)
+	rm $(PREFIX)/bin/$(BINNAME)
+	rm $(PREFIX)/share/applications/$(BINNAME).desktop
+
+clean: ./$(BINNAME)
+	rm $(BINNAME)

--- a/README.md
+++ b/README.md
@@ -27,22 +27,51 @@ Then go ahead and clone the repository.
 git clone https://github.com/fdiskzlez/anterminal.git anterminal
 ```
 
-So now, you can go inside the source tree and type `./install.sh` to build and install anterminal!
+So now, you can go inside the source tree and type `sudo make install` to build and install
+anterminal!
 
 ```sh
 cd anterminal
-chmod +x install.sh
-./install.sh
+sudo make install
 ```
 
-> [!TIP]
-> To clean the object files and the binary from the source tree, you may've to run `make clean`
+> [!NOTE]
+> By default anterminal will use the installation prefix `/usr/local` so you'll get
+> `/usr/local/bin/anterminal` and `/usr/local/share/applications/anterminal.desktop`.
+
+## Tips
+
+### Cleaning the source tree
+
+You can use:
+
+```sh
+sudo make clean
+```
+
+### Specifying an installation prefix
+
+You can install anterminal in a specified prefix instead, so per example, you can do
+something like this which is useful when, per example, packaging anterminal.
+
+```
+mkdir -pv ~/rootfs
+sudo make clean
+make clean
+make PREFIX=$HOME/rootfs install
+```
+
+And to uninstall from that ~/rootfs folder
+
+```sh
+make PREFIX=$HOME/rootfs uninstall
+```
 
 ## Customizing
 
 For customization, I (NameGoesThere) worked my ass off for 3 hours getting .conf support working. So here is how you do it. <br>
 Go into your .config folder (~/.config), then make a file named anterminal.conf <br>
-Once you have opened anterminal.conf with something like vim or nano, ther are a lot of things you are able to change.
+Once you have opened anterminal.conf with something like vim or nano, there are a lot of things you are able to change.
 
 ### Example conf
 ```
@@ -79,16 +108,18 @@ To rebuild the thing, u need to first clean the folder with
 make clean
 ```
 
+> Note that you may require to use sudo if you installed with `sudo make install`
+
 and then properly build it with
 
 ```sh
 make
 ```
 
-and then install it with
+and then install it with using the `install` target again
 
 ```sh
-sudo install -Dvm755 ./anterminal /usr/local/bin/anterminal
+sudo make install
 ```
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ and then properly build it with
 make
 ```
 
-and then install it with using the `install` target again
+and then install it using the `install` target again
 
 ```sh
 sudo make install

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ make clean
 make PREFIX=$HOME/rootfs install
 ```
 
+Which results in something like this:
+
+```
+$ tree ~/rootfs
+/home/user/rootfs
+├── bin
+│  └── anterminal
+└── share
+   └── applications
+      └── anterminal.desktop
+```
+
 And to uninstall from that ~/rootfs folder
 
 ```sh

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,0 @@
-make clean
-make
-sudo install -Dvm755 ./anterminal /usr/local/bin/anterminal
-sudo install -Dvm755 ./anterminal.desktop /usr/share/applications/anterminal.desktop


### PR DESCRIPTION
This PR embeds the steps provided by install.sh but inside the `Makefile` so it gets easier to build & install the project.

Instructions in the readme.md has been updated but here's a short resume

```sh
git clone https://github.com/antma-window-manager/anterminal.git && cd anterminal
make
sudo make install
```

the PREFIX variable is provided so the user can install the project wherever they want to, example:

```sh
mkdir -pv ~/rootfs
sudo make clean
make PREFIX=$HOME/rootfs install
```

Which results in

```
$ tree ~/rootfs
/home/anon/rootfs
├── bin
│  └── anterminal
└── share
   └── applications
      └── anterminal.desktop
```